### PR TITLE
Recreating plugin instance if new options were provided.

### DIFF
--- a/jquery.isloading.js
+++ b/jquery.isloading.js
@@ -154,7 +154,7 @@
     // Constructor
     $.fn[pluginName] = function ( options ) {
         return this.each(function () {
-            if ( !$.data( this, "plugin_" + pluginName ) ) {
+            if ( options && "hide" !== options || !$.data( this, "plugin_" + pluginName ) ) {
                 $.data( this, "plugin_" + pluginName, new Plugin( this, options ) );
             } else {
                 var elt = $.data( this, "plugin_" + pluginName );


### PR DESCRIPTION
In previous version setting new text didn't take effect id it was set second time:
$.isLoading({text: 'Loading user data...'});
$.isLoading('hide');
$isLoading({text: 'Sending message...'});
caused showing of "Loading user data..." loading message twice.

I've added recreation of plugin instance if new "non-hide" options were provided. This will allow to change options dynamically.
