### PR TITLE
Allow hide for multiple elements seperately

### DIFF
--- a/jquery.isloading.js
+++ b/jquery.isloading.js
@@ -140,7 +140,7 @@
 
             if( "overlay" === this.options.position ) {
 
-                $( ".isloading-overlay" ).remove();
+                $( this.element ).find( ".isloading-overlay" ).remove();
 
             } else {
 


### PR DESCRIPTION
Updated the hide function so it would make use of the queried element.

This is helpful in situations where you might be making use of multiple overlays on several elements. If you were using multiple elements, previously, and called $({query}).isLoading("hide"); all overlays would disappear at once since the overlay if was just looking for the common class.
