### PR TITLE
Clean up resize event handler on window for v1.0.6

### DIFF
--- a/jquery.isloading.js
+++ b/jquery.isloading.js
@@ -57,9 +57,10 @@
         // Merge user options with default ones
         this.options = $.extend( {}, defaults, options );
 
-        this._defaults     = defaults;
-        this._name         = pluginName;
-        this._loader       = null;                // Contain the loading tag element
+        this._defaults       = defaults;
+        this._name           = pluginName;
+        this._loader         = null;                // Contain the loading tag element
+        this._resizeCallback = null;                // Callback attached to window to handle resize event for overlays
 
         this.init();
     }
@@ -118,10 +119,10 @@
                         $wrapperTpl = $('<div class="isloading-overlay" style="position:fixed; left:0; top:0; z-index: 10000; background: rgba(0,0,0,0.5); width: 100%; height: ' + $(window).height() + 'px;" />');
                         $( "body" ).prepend( $wrapperTpl );
 
-                        $( window ).on('resize', function() {
+                        self._resizeCallback = function() {
                             $wrapperTpl.height( $(window).height() + 'px' );
                             self._loader.css({top: ($(window).height()/2 - self._loader.outerHeight()/2) + 'px' });
-                        });
+                        };
                     } else {
                         var cssPosition = $( self.element ).css('position'),
                             pos = {},
@@ -136,11 +137,12 @@
                         $wrapperTpl = $('<div class="isloading-overlay" style="position:absolute; top: ' + pos.top + 'px; left: ' + pos.left + 'px; z-index: 10000; background: rgba(0,0,0,0.5); width: ' + width + '; height: ' + height + ';" />');
                         $( self.element ).prepend( $wrapperTpl );
 
-                        $( window ).on('resize', function() {
+                        self._resizeCallback = function() {
                             $wrapperTpl.height( $( self.element ).outerHeight() + 'px' );
                             self._loader.css({top: ($wrapperTpl.outerHeight()/2 - self._loader.outerHeight()/2) + 'px' });
-                        });
+                        };
                     }
+                    $( window ).on('resize', self._resizeCallback);
 
                     $wrapperTpl.html( self._loader );
                     self._loader.css({top: ($wrapperTpl.outerHeight()/2 - self._loader.outerHeight()/2) + 'px' });
@@ -159,6 +161,10 @@
             if( "overlay" === this.options.position ) {
 
                 $( this.element ).find( ".isloading-overlay" ).first().remove();
+                if (this._resizeCallback) {
+                    $( window ).off('resize', this._resizeCallback);
+                    this._resizeCallback = null;
+                }
 
             } else {
 


### PR DESCRIPTION
Hey!

I'm using the old 1.0.6 release in my project, and the resize handler attached to window isn't getting removed when hiding an element show with the overlay position. This is important to me as my project uses an SPA approach, so I don't want event handlers to accumulate over time as I show and hide overlays.

This is intended to correct v1 behaviour, not v2.

**What kind of change does this PR introduce?**:
Remembers the resize handler's reference so it can be removed later.

**Did you add tests for your changes?**:
No.

**Does this PR introduce a breaking change?**:
No.

**Other**:
This code is a bugfix based on 36795a74, so it should be applied to a 1.x branch, not master, if accepted.

Thanks! :)